### PR TITLE
Add in-memory FastAPI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ NotaNova es un backend construido con [FastAPI](https://fastapi.tiangolo.com/) y
 pip install -r requirements.txt
 ```
 
+## Demo sin base de datos
+
+```bash
+uvicorn app.demo:app --reload
+```
+
+Este modo usa almacenamiento en memoria, por lo que los datos se pierden al reiniciar la aplicación.
+
 ## Ejecución local
 
 ```bash

--- a/app/demo.py
+++ b/app/demo.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+
+from .models import Note, Reminder
+
+app = FastAPI(title="NotaNova Demo")
+
+notes: list[Note] = []
+reminders: list[Reminder] = []
+
+_note_id_counter = 1
+_reminder_id_counter = 1
+
+
+@app.get("/notes", response_model=list[Note])
+def read_notes() -> list[Note]:
+    return notes
+
+
+@app.post("/notes", response_model=Note)
+def create_note(note: Note) -> Note:
+    global _note_id_counter
+    note.id = _note_id_counter
+    _note_id_counter += 1
+    notes.append(note)
+    return note
+
+
+@app.get("/reminders", response_model=list[Reminder])
+def read_reminders() -> list[Reminder]:
+    return reminders
+
+
+@app.post("/reminders", response_model=Reminder)
+def create_reminder(reminder: Reminder) -> Reminder:
+    global _reminder_id_counter
+    reminder.id = _reminder_id_counter
+    _reminder_id_counter += 1
+    reminders.append(reminder)
+    return reminder


### PR DESCRIPTION
## Summary
- add `app/demo.py` for an in-memory Notes and Reminders API
- document how to run the demo without any database

## Testing
- `pytest`
- `python -m py_compile app/demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68921d46ed18832f983f9adcd7f9c848